### PR TITLE
WASM-Bigint is no longer experimental, so we can/have to omit the flag.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --experimental-wasi-unstable-preview1 --experimental-wasm-bigint --project ./server/tsconfig.json --respawn  ./server/index.ts",
     "start": "tsc --project ./server/tsconfig.json",
-    "poststart": "node ./dist/index.js"
+    "poststart": "node --experimental-wasi-unstable-preview1  ./dist/index.js"
   },
   "engines": {
     "node": ">=12.18.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "ts-node-dev --experimental-wasi-unstable-preview1 --experimental-wasm-bigint --project ./server/tsconfig.json --respawn  ./server/index.ts",
     "start": "tsc --project ./server/tsconfig.json",
-    "poststart": "node --experimental-wasi-unstable-preview1  --experimental-wasm-bigint ./dist/index.js"
+    "poststart": "node ./dist/index.js"
   },
   "engines": {
     "node": ">=12.18.1"


### PR DESCRIPTION
From here: https://github.com/sonictruth/tetra-kit-player/pull/3